### PR TITLE
Update trains example so that SPARK can be run

### DIFF
--- a/ARM/STMicro/STM32/examples/train/src/trains.adb
+++ b/ARM/STMicro/STM32/examples/train/src/trains.adb
@@ -34,7 +34,7 @@ package body Trains with
 is
 
    procedure Update_Track_Signal (Track : Track_Id) with
-     Global => (Input  => (Trains, Cur_Num_Trains),
+     Global => (Input  => (Trains, Cur_Num_Trains, Previous_Tracks, Tracks),
                 In_Out => Track_Signals),
      Pre  => Track_Signals (Track) = Orange,
      Post => (if (for some T in Train_Id range 1 .. Cur_Num_Trains =>

--- a/ARM/STMicro/STM32/examples/train/src/trains.ads
+++ b/ARM/STMicro/STM32/examples/train/src/trains.ads
@@ -237,7 +237,7 @@ is
       New_Position : Train_Position;
       Result       : out Move_Result)
    with
-     Global => (Input  => Cur_Num_Trains,
+     Global => (Input  => (Cur_Num_Trains, Previous_Tracks, Tracks),
                 In_Out => (Trains, Track_Signals)),
      Pre  => Train in 1 .. Cur_Num_Trains and then
              Valid_Move (Trains (Train), New_Position) and then


### PR DESCRIPTION
I tried running SPARK on the trains example, and fixed a couple errors about global variable access not being declared.