### PR TITLE
Fixed error in calculation of the USART BRR register value.

### DIFF
--- a/ARM/STMicro/STM32/drivers/stm32f4-usarts.adb
+++ b/ARM/STMicro/STM32/drivers/stm32f4-usarts.adb
@@ -131,7 +131,7 @@ package body STM32F4.USARTs is
 
    procedure Set_Baud_Rate (This : in out USART; To : Baud_Rates) is
       Clock        : constant Word := APB_Clock (This);
-      Int_Divider  : constant Word := (25 * Clock) / (4 * To);
+      Int_Divider  : constant Word := (25 * Clock) / (2 * To);
       Frac_Divider : constant Word := Int_Divider rem 100;
       BRR          : Half_Word;
    begin


### PR DESCRIPTION
The calculation of the BRR value to set up the baud rate of an USART interface uses a wrong factor for the `Int_Divider` calculation. This always results in twice the baud rate as requested by the `To` parameter. 
This fix is consistent with the formula used in the official STM32F4 HAL by ST.