### PR TITLE
STM32F4-GPIO : Modify procedure and function to allow non-variable GPIO_Point parameters

### DIFF
--- a/ARM/STMicro/STM32/drivers/stm32f4-gpio.adb
+++ b/ARM/STMicro/STM32/drivers/stm32f4-gpio.adb
@@ -126,7 +126,7 @@ package body STM32F4.GPIO is
    -- Set --
    ---------
 
-   procedure Set (This : in out GPIO_Point) is
+   procedure Set (This : GPIO_Point) is
    begin
       This.Port.BSRR_Set := GPIO_Pin'Enum_Rep (This.Pin);
    end Set;
@@ -157,7 +157,7 @@ package body STM32F4.GPIO is
    -- Clear --
    -----------
 
-   procedure Clear (This : in out GPIO_Point) is
+   procedure Clear (This : GPIO_Point) is
    begin
       This.Port.BSRR_Reset := GPIO_Pin'Enum_Rep (This.Pin);
    end Clear;
@@ -196,7 +196,7 @@ package body STM32F4.GPIO is
    -- Toggle --
    ------------
 
-   procedure Toggle (This : in out GPIO_Point) is
+   procedure Toggle (This : GPIO_Point) is
    begin
       This.Port.ODR := This.Port.ODR xor GPIO_Pin'Enum_Rep (This.Pin);
    end Toggle;

--- a/ARM/STMicro/STM32/drivers/stm32f4-gpio.ads
+++ b/ARM/STMicro/STM32/drivers/stm32f4-gpio.ads
@@ -127,7 +127,7 @@ package STM32F4.GPIO is
    --  For the given GPIO port, sets all of the output data register bits
    --  specified by Pins to one. Other pins are unaffected.
 
-   procedure Set (This : in out GPIO_Point) with Inline;
+   procedure Set (This : GPIO_Point) with Inline;
    --  For This.Port.all, sets the output data register bit specified by
    --  This.Pin to one. Other pins are unaffected.
 
@@ -140,7 +140,7 @@ package STM32F4.GPIO is
    --  For the given GPIO port, sets of all of the output data register bits
    --  specified by Pins to zero. Other pins are unaffected.
 
-   procedure Clear (This : in out GPIO_Point) with Inline;
+   procedure Clear (This : GPIO_Point) with Inline;
    --  For This.Port.all, sets the output data register bit specified by
    --  This.Pin to zero. Other pins are unaffected.
 
@@ -153,7 +153,7 @@ package STM32F4.GPIO is
    --  specified by Pins (ones become zeros and vice versa). Other pins are
    --  unaffected.
 
-   procedure Toggle (This : in out GPIO_Point) with Inline;
+   procedure Toggle (This : GPIO_Point) with Inline;
    --  For This.Port.all, negates the output data register bit specified by
    --  This.Pin (one becomes zero and vice versa). Other pins are unaffected.
 


### PR DESCRIPTION
Hi,

I noticed some functions where parameters are in out in the signature when the body only read the parameters value. As I was passing non variable parameters it causes compilation errors fixed by this commit.

I take a look at your svd branch where the procedure and function signatures are modified in the same way.

I'm new in the Ada so I may have missed something. I would be grateful for any remark explaining how to improve things.

Best regards,