### PR TITLE
Removed aspect "Pack", because it conflicts with aspect "Size"

### DIFF
--- a/ARM/STMicro/STM32/drivers/stm32f4.ads
+++ b/ARM/STMicro/STM32/drivers/stm32f4.ads
@@ -74,9 +74,9 @@ package STM32F4 is
    type Bits_29 is mod 2**29 with Size => 29;
    type Bits_30 is mod 2**30 with Size => 30;
 
-   type Bits_32x1 is array (0 .. 31) of Bits_1 with Pack, Size => 32;
-   type Bits_16x2 is array (0 .. 15) of Bits_2 with Pack, Size => 32;
-   type Bits_8x4  is array (0 ..  7) of Bits_4 with Pack, Size => 32;
+   type Bits_32x1 is array (0 .. 31) of Bits_1 with Size => 32;
+   type Bits_16x2 is array (0 .. 15) of Bits_2 with Size => 32;
+   type Bits_8x4  is array (0 ..  7) of Bits_4 with Size => 32;
 
    --  Define address bases for the various system components
 


### PR DESCRIPTION
The aspect "Pack" will tell the compiler to compress the array, so it will choose the smallest possible representation. However we want a fixed size with the "Size" aspect, therefore aspect "Pack" conflicts with aspect "Size". Luckily, the compiler may (and actually does) ignore the aspect "Pack".

See: https://en.wikibooks.org/wiki/Ada_Programming/Pragmas/Pack#Exact_data_representation